### PR TITLE
Add resetMeta function which makes it easier to apply ngMeta defaults

### DIFF
--- a/src/ngMeta.js
+++ b/src/ngMeta.js
@@ -181,7 +181,7 @@
          */
         var resetMeta = function() {
           return readRouteMeta();
-        }
+        };
 
         /**
          * @ngdoc method

--- a/src/ngMeta.js
+++ b/src/ngMeta.js
@@ -170,6 +170,18 @@
           readRouteMeta(angular.copy(current.meta || (current.data && current.data.meta)));
         };
 
+        /**
+         * @ngdoc method
+         * @name resetMeta
+         * @description
+         * Helper function to reset ngMeta data and apply defaults. Useful when setting up ngmeta data in a
+         * UI-router resolve function.
+         *
+         * @returns {Object} self
+         */
+        var resetMeta = function() {
+          return readRouteMeta();
+        }
 
         /**
          * @ngdoc method
@@ -203,7 +215,8 @@
           'init': init,
           'setTitle': setTitle,
           'setTag': setTag,
-          'setDefaultTag': setDefaultTag
+          'setDefaultTag': setDefaultTag,
+          'resetMeta' : resetMeta
         };
       }
 

--- a/test/ngMeta.spec.js
+++ b/test/ngMeta.spec.js
@@ -345,4 +345,63 @@ describe('Service: ngMeta', function() {
     });
   });
 
+  describe('resetMeta: resetMeta()', function() {
+
+    describe('Basic checks', function() {
+      //Inject dependencies
+      beforeEach(function() {
+        injectDependencies();
+      });
+
+      it('should provide an resetMeta() function', function() {
+        expect(ngMeta.resetMeta).toBeDefined();
+      });
+    });
+
+    describe('Standard functionality', function() {
+
+      beforeEach(function() {
+        module(function(ngMetaProvider) {
+          ngMetaProvider.setDefaultTag(SOME_TAG, SOME_TAG_DEFAULT_VALUE);
+        });
+        injectDependencies();
+        ngMeta.init();
+      });
+
+      it('should set default values', function() {
+        ngMeta.resetMeta();
+
+        //default value available immediately
+        expect($rootScope.ngMeta[SOME_TAG]).toEqual(SOME_TAG_DEFAULT_VALUE);
+        // default value should still be present after state change
+        $rootScope.$broadcast('$stateChangeSuccess', { meta: { disableUpdate: true } });
+        expect($rootScope.ngMeta[SOME_TAG]).toEqual(SOME_TAG_DEFAULT_VALUE);        
+      });
+
+      it('should overwrite a previous default value', function() {
+        ngMeta.resetMeta();
+        ngMeta.setTag(SOME_TAG, SOME_TAG_VALUE);
+
+        $rootScope.$broadcast('$stateChangeSuccess', { meta: { disableUpdate: true } });
+        expect($rootScope.ngMeta[SOME_TAG]).not.toEqual(SOME_TAG_DEFAULT_VALUE);
+      });
+
+      it('should not overwrite a previous default value is state does not include disableUpdate', function() {
+        ngMeta.resetMeta();
+        ngMeta.setTag(SOME_TAG, SOME_TAG_VALUE);
+
+        $rootScope.$broadcast('$stateChangeSuccess', { meta: { disableUpdate: false } });
+        expect($rootScope.ngMeta[SOME_TAG]).toEqual(SOME_TAG_DEFAULT_VALUE);
+      });
+
+      it('should overwrite a non-default value', function() {
+        ngMeta.resetMeta();
+        ngMeta.setTitle(SOME_TITLE);
+        $rootScope.$broadcast('$stateChangeSuccess', { meta: { disableUpdate: true } });
+
+        expect($rootScope.ngMeta[SOME_TAG]).toEqual(SOME_TAG_DEFAULT_VALUE);
+        expect($rootScope.ngMeta.title).toEqual(SOME_TITLE);   
+      });
+    });
+  });
 });


### PR DESCRIPTION
when configuring ngMeta data inside a UI Router resolve function I had to manually apply all the default tags I setup in the app configuration phase. By exposing a reset function I can simply call ngMeta.resetMeta() inside my resolve function and not need to know which defaults have been setup.