### PR TITLE
Check for the current before processing the meta.

### DIFF
--- a/src/ngMeta.js
+++ b/src/ngMeta.js
@@ -167,6 +167,7 @@
         };
 
         var update = function(event, current) {
+          if (!current) return;
           readRouteMeta(angular.copy(current.meta || (current.data && current.data.meta)));
         };
 


### PR DESCRIPTION
In a hybrid app, we need to ensure that we have a current route, as it isn't a guarantee. In this, I check before we pull the meta from undefined and get an error that kills the route changing. 